### PR TITLE
Configure fails against zookeeper trunk

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -49,7 +49,7 @@ if test "$PHP_ZOOKEEPER" != "no"; then
   else
     AC_MSG_RESULT([$PHP_LIBZOOKEEPER_DIR])
     if test -r "$PHP_LIBZOOKEEPER_DIR/include/zookeeper.h"; then
-      PHP_LIBZOOKEEPER_INCDIR="$PHP_LIBZOOKEEPER_DIR/include/c-client-src"
+      PHP_LIBZOOKEEPER_INCDIR="$PHP_LIBZOOKEEPER_DIR/include"
     elif test -r "$PHP_LIBZOOKEEPER_DIR/include/zookeeper/zookeeper.h"; then
       PHP_LIBZOOKEEPER_INCDIR="$PHP_LIBZOOKEEPER_DIR/include/zookeeper"
     fi


### PR DESCRIPTION
configure is looking for zookeeper.h in a non-existent path (include/c-client-src/zookeeper.h). In current trunk, zookeeper.h is located at: include/
