### PR TITLE
Respect null's when passed as values during set(), create(), and get().

### DIFF
--- a/php_zookeeper.c
+++ b/php_zookeeper.c
@@ -209,9 +209,9 @@ static PHP_METHOD(Zookeeper, create)
 	}
 	realpath = emalloc(realpath_max);
 
-    if (value == NULL) {
-        value_len = -1;
-    }
+	if (value == NULL) {
+		value_len = -1;
+	}
 
 	php_parse_acl_list(acl_info, &aclv);
 	status = zoo_create(i_obj->zk, path, value, value_len, (acl_info ? &aclv : 0), flags,
@@ -339,10 +339,10 @@ static PHP_METHOD(Zookeeper, get)
 					  cb_data, buffer, &length, &stat);
 	buffer[length] = 0;
 
-    /* Length will be returned as -1 if the znode carries a NULL */
-    if (length == -1) {
-        RETURN_NULL();
-    }
+	/* Length will be returned as -1 if the znode carries a NULL */
+	if (length == -1) {
+		RETURN_NULL();
+	}
 
 	if (status != ZOK) {
 		efree (buffer);
@@ -426,9 +426,9 @@ static PHP_METHOD(Zookeeper, set)
 	if (stat_info) {
 		stat_ptr = &stat;
 	}
-    if (value == NULL) {
-        value_len = -1;
-    }
+	if (value == NULL) {
+		value_len = -1;
+	}
 	status = zoo_set2(i_obj->zk, path, value, value_len, version, stat_ptr);
 	if (status != ZOK) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error: %s", zerror(status));


### PR DESCRIPTION
This change set fixes NULL handling in php-zookeeper.

Before (notice my null gets cast to string):

```
php > $z = new Zookeeper('127.0.0.1:2181');
php > $z->create('/test', null, array(array('perms' => Zookeeper::PERM_ALL, 'scheme' => 'world', 'id' => 'anyone')));
php > var_dump($z->get('/test'));
string(0) ""
```

After (null is preserved):

```
php > $z = new Zookeeper('127.0.0.1:2181');
php > $z->create('/test', null, array(array('perms' => Zookeeper::PERM_ALL, 'scheme' => 'world', 'id' => 'anyone')));
php > var_dump($z->get('/test'));
NULL
php >
```

This patch also fixes a segfault. If there is a znode in your zookeeper server somewhere with a NULL value and you attempt to read it, you get this:

```
php > var_dump($z->get('/test'));
string(-1) "Segmentation fault
```

With this patch, this would look more like this:

```
php > var_dump($z->get('/test'));
NULL
```
