### PR TITLE
Return null after zoo_exists returning 0-length directly.

### DIFF
--- a/php_zookeeper.c
+++ b/php_zookeeper.c
@@ -336,6 +336,9 @@ static PHP_METHOD(Zookeeper, get)
 		length = max_size;
 	}
 
+	if (length <= 0) /* znode carries a NULL */
+		RETURN_NULL();
+
 	buffer = emalloc (length+1);
 	status = zoo_wget(i_obj->zk, path, (fci.size != 0) ? php_zk_watcher_marshal : NULL,
 					  cb_data, buffer, &length, &stat);


### PR DESCRIPTION
When i tried this,

    <?php
    $zk = new Zookeeper("localhost:2181");
    $path = "/brokers/topics";
    $value = $zk->get($path);
    var_dump($value);

i got a fatal error:

    PHP Fatal error:  Possible integer overflow in memory allocation (4 * 18446744073709551615 + 1) in /home/xxx/zk.php on line 5
    PHP Stack trace:
    PHP   1. {main}() /home/xxx/zk.php:0
    PHP   2. var_dump() /home/xxx/zk.php:5

After that, i found that when the znode carries a NULL value, zoo_wget returns 4294967295 (instead of -1) under 64-bit system.

So, i changed the circuit to: when zoo_exists returns a 0-length value, Zookeeper::get returns NULL at once.

---- PATCHED ----

This is the output when trying to get a NULL value:

    NULL

This is the output when trying to get a normal value:

    string(36) "{"version":1,"partitions":{"0":[0]}}"

